### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cloudcix
-django==2.2
+django==2.2.28
 openapi-spec-validator==0.2.9
 pyyaml
 serpy


### PR DESCRIPTION
API framework that uses docgen to generate the docs version for Django is being proposed from 2.2. to 2.2.28