### PR TITLE
improvements

### DIFF
--- a/docgen/defaults.py
+++ b/docgen/defaults.py
@@ -11,7 +11,7 @@ DEFAULT_SPEC = {
     },
     'tags': [],
     'security': [
-        {'api_key': []},
+        {'XAuthToken': []},
     ],
     'paths': {},
     'components': {
@@ -67,7 +67,7 @@ DEFAULT_SPEC = {
             },
         },
         'securitySchemes': {
-            'auth_token': {
+            'XAuthToken': {
                 'type': 'apiKey',
                 'in': 'header',
                 'name': 'X-Auth-Token',
@@ -161,7 +161,7 @@ DEFAULT_LIST_PARAMETERS = [
         'description': 'The limit of the number of objects returned per page',
         'required': False,
         'schema': {
-            'type': 'integer',
+            'type': 'number',
             'minimum': 0,
             'maximum': 100,
             'default': 50,
@@ -185,7 +185,7 @@ DEFAULT_LIST_PARAMETERS = [
         'description': 'The page of records to return, assuming `limit` number of records per page.',
         'required': False,
         'schema': {
-            'type': 'integer',
+            'type': 'number',
             'minimum': 0,
             'default': 0,
         },

--- a/docgen/defaults.py
+++ b/docgen/defaults.py
@@ -161,7 +161,7 @@ DEFAULT_LIST_PARAMETERS = [
         'description': 'The limit of the number of objects returned per page',
         'required': False,
         'schema': {
-            'type': 'number',
+            'type': 'integer',
             'minimum': 0,
             'maximum': 100,
             'default': 50,
@@ -185,7 +185,7 @@ DEFAULT_LIST_PARAMETERS = [
         'description': 'The page of records to return, assuming `limit` number of records per page.',
         'required': False,
         'schema': {
-            'type': 'number',
+            'type': 'integer',
             'minimum': 0,
             'default': 0,
         },

--- a/docgen/management/commands/docgen.py
+++ b/docgen/management/commands/docgen.py
@@ -822,6 +822,18 @@ order, while `?order=-field` orders in descending order instead.
                     elif str(code) == '200' and self.method_name == 'get' and self.get_is_list:
                         default['application/json']['schema']['$ref'] = f'#/components/schemas/{self.model_name}List'
                         details['content'] = default
+                        details['count'] = {
+                            'type': 'integer',
+                            'description': 'Maximum number of records returned per page.',
+                        }
+                        details['page'] = {
+                            'type': 'integer',
+                            'description': 'Page number of the current results.',
+                        }
+                        details['total'] = {
+                            'type': 'integer',
+                            'description': 'Total number of matching records.',
+                        }
 
             # Remove anything that has its value as 'none' (i.e. to have no content)
             for k in list(details.keys()):

--- a/docgen/management/commands/docgen.py
+++ b/docgen/management/commands/docgen.py
@@ -379,32 +379,42 @@ class Command(BaseCommand):
             f'\t\t\tparse_controller: Attempting to parse Controller for {self.model_name}.{self.method_name}',
         )
         # Check if this is a list method and if so, add filter and order details to description, and add params
-        if self.method_name == 'get' and self.get_is_list:
-            if explicit_controller_name is None:
-                self.controller_class = getattr(self.controller_mod, f'{self.model_name}ListController', None)
+        if self.method_name == 'get':
+            if self.get_is_list:
+                if explicit_controller_name is None:
+                    self.controller_class = getattr(self.controller_mod, f'{self.model_name}ListController', None)
+                else:
+                    self.controller_class = getattr(self.controller_mod, explicit_controller_name, None)
+                if self.controller_class is not None:
+                    try:
+                        self.method_spec['description'] += '\n\n' + self.get_list_details()
+                    except KeyError:
+                        self.logger.error(f'parse_controller: No list description found for {self.url}', exc_info=True)
+                        self.errors = True
+                        return
+                # Also add the default parameters
+                self.method_spec.setdefault('parameters', [])
+                self.method_spec['parameters'] += defaults.DEFAULT_LIST_PARAMETERS
             else:
-                self.controller_class = getattr(self.controller_mod, explicit_controller_name, None)
-            if self.controller_class is not None:
-                try:
-                    self.method_spec['description'] += '\n\n' + self.get_list_details()
-                except KeyError:
-                    self.logger.error(f'parse_controller: No list description found for {self.url}', exc_info=True)
-                    self.errors = True
-                    return
-            # Also add the default parameters
-            self.method_spec.setdefault('parameters', [])
-            self.method_spec['parameters'] += defaults.DEFAULT_LIST_PARAMETERS
+               if explicit_controller_name is None:
+                    self.controller_class = getattr(self.controller_mod, f'{self.model_name}ReadController', None) 
         # Otherwise, check if it is a create or update request and parse the requestBody details from the controller
-        elif self.method_name in ['post', 'put']:
-            if explicit_controller_name is None:
-                controller_type = 'Create' if self.method_name == 'post' else 'Update'
-                self.controller_class = getattr(
-                    self.controller_mod,
-                    f'{self.model_name}{controller_type}Controller',
-                    None,
-                )
+        else:
+            if self.method_name == 'post':
+                controller_type = 'Create'
+            elif self.method_name == 'put':
+                controller_type = 'Update'
+            elif self.method_name == 'patch':
+                controller_type = 'Update'
+            elif self.method_name == 'delete':
+                controller_type = 'Delete'
             else:
-                self.controller_class = getattr(self.controller_mod, explicit_controller_name, None)
+                return
+            self.controller_class = getattr(
+                self.controller_mod,
+                f'{self.model_name}{controller_type}Controller',
+                None,
+            )
         if self.controller_class is not None:
             self.parse_input_schema()
 
@@ -420,8 +430,10 @@ class Command(BaseCommand):
             operation = 'create'
         elif 'Update' in schema_name:
             operation = 'update'
-        else:
+        elif 'List' in schema_name:
             operation = 'list'
+        else:
+            return
 
         if operation == 'list' and self.controller_class.Meta.validation_order == ('search', 'exclude', 'limit', 'page', 'order'):
             return
@@ -801,8 +813,7 @@ order, while `?order=-field` orders in descending order instead.
                     # Skip code 204 because it doesn't matter
 
                     # If created, read or updated
-                    if str(code) == '201' or (str(code) == '200' and (
-                            self.method_name != 'get' or not self.get_is_list)):
+                    if str(code) == '201' or (str(code) == '200' and (self.method_name != 'get' or not self.get_is_list)):
                         # Return <Model>Response
                         default['application/json']['schema']['$ref'] = (
                             f'#/components/schemas/{self.model_name}Response'

--- a/docgen/management/commands/docgen.py
+++ b/docgen/management/commands/docgen.py
@@ -634,6 +634,18 @@ class Command(BaseCommand):
                         '$ref': f'#/components/schemas/{self.model_name}',
                     },
                 },
+                'count': {
+                    'description': 'Maximum number of records returned per page.',
+                    'type': 'integer',
+                },
+                'page': {
+                    'description': 'Page number of the current results.',
+                    'type': 'integer',
+                },
+                'total': {
+                    'description': 'Total number of matching records.',
+                    'type': 'integer',
+                },
                 '_metadata': {
                     '$ref': '#/components/schemas/ListMetadata',
                 },
@@ -822,18 +834,6 @@ order, while `?order=-field` orders in descending order instead.
                     elif str(code) == '200' and self.method_name == 'get' and self.get_is_list:
                         default['application/json']['schema']['$ref'] = f'#/components/schemas/{self.model_name}List'
                         details['content'] = default
-                        details['count'] = {
-                            'type': 'integer',
-                            'description': 'Maximum number of records returned per page.',
-                        }
-                        details['page'] = {
-                            'type': 'integer',
-                            'description': 'Page number of the current results.',
-                        }
-                        details['total'] = {
-                            'type': 'integer',
-                            'description': 'Total number of matching records.',
-                        }
 
             # Remove anything that has its value as 'none' (i.e. to have no content)
             for k in list(details.keys()):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='docgen',
-    version='1.2.0',
+    version='1.3.0',
     description='OpenAPI Documentation Generator for CloudCIX Applications',
     long_description=readme,
     author='CloudCIX',


### PR DESCRIPTION
1. Resolve Security/SchemeNotFound for api_key
    - security: It is of the scheme XAuthToken 
2. Resolve Method/RequestBodyNotSupported
    - `self.controller_name` was in memory for requests, added default for each method and if it does not exist, do not add requestBody
3. Resolve Pagination/NotConfigured
    - `page`, `count` and `total` expected in top level of list response instead of as `page`, `limit` and `total_records` in `_metadata` object. 